### PR TITLE
More granular control of shared folders

### DIFF
--- a/vagrant.yml.dist
+++ b/vagrant.yml.dist
@@ -6,7 +6,8 @@ synced_folders:
     # rsync: the best performance, cross-platform platform, one-way only. Run `vagrant rsync-auto` to start auto sync.
     #   When using rsync sync type the "folders" list below is mandatory.
     # vboxfs (or leave empty): best compatibility and ease of setup, but poor performance.
-    type: 'nfs'
+    # If you want to mount the root directory, add your preferred method (nfs, smb, etc) to the following line
+    default_mount_type:
     # smb_user, smb_password - The username and password used for authentication to mount the SMB mount.
     # This is usually your Windows username and password, unless you created a dedicated user for vagrant.
     # If using the 'smb2' type above the user and share will be configured automatically.
@@ -14,10 +15,22 @@ synced_folders:
     smb_password: 'vagrant'
     # List of folders to sync with rsync. These should be subfolder names within the <Projects> folder (e.g. "drupal7")
     # Uncomment and add folders per the example below as neccessary.
-    folders:
+    rsync_folders:
       #- "projectA"  # rsync projectA folder
       #- "projectB"  # rsync projectB folder
       #- ""  # rsync the whole <Projects> folder. WARNING: don't do this if your <Projects> folder is big.
+    # List of folders to mount individually. This is really only needed in the case where you want a container to write
+    # something back to the Host OS. If that describes your situation, use type = vboxfs. If you just want more control
+    # over what's mounted, go with type = nfs, which is much faster.
+    individual_mounts:
+      #- location: './logs'
+      #  mount: '/home/docker/logs'
+      #  type: 'vboxfs'
+      #  options: 'uid=999,gid=50'
+      #- location: './logs'
+      #  mount: '/home/docker/logs'
+      #  type: 'nfs'
+      #  options: 'nolock,vers=3,tcp'
 
 # VirtualBox VM settings
 v.gui: false  # Set to true for debugging. Will unhide VM's primary console screen.


### PR DESCRIPTION
This pull request (optionally) provides more granular control over shared folders. By defining a given share (see: individual_mounts in vagrant.yml.dist) with a type of 'vboxfs' and mounting it with uid=999 (or whatever is applicable for the container you're running), the container then has the ability to make writes that show up on the Host OS as well. NFS is also supported on the individual mounts, and smb and rsync could be added as well without any difficulty.

This need came about because I've been tasked with working on a phalcon-php app that writes log files to a directory inside the web root. I had almost given up on finding a solution that would let me use docker until I found your project and made a few tweaks to it to mount folders in a way that allowed them to be written to.

The only other changes are:
- disabling the default mount at /vagrant, since that mount was being duplicated elsewhere
- a few key name changes in the synced_folders section to make my individual_mounts inclusion a bit more clear

Hopefully someone else find this change useful as well.
