### PR TITLE
Use kvm for paravirt to improve CPU performance

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -193,6 +193,10 @@ Vagrant.configure("2") do |config|
     # See https://github.com/docker/machine/pull/1069
     v.customize ['modifyvm', :id, '--natdnshostresolver1', 'off']
     v.customize ['modifyvm', :id, '--natdnsproxy1', 'off']
+
+    # VirtualBox 5 supports paravirtualization, and defaults this setting to
+    # 'legacy' which isn't enabling KVM.
+    v.customize ['modifyvm', :id, '--paravirtprovider', 'kvm']
   end
 
   ## Provisioning scripts ##


### PR DESCRIPTION
On my local, this improves ab results on Drupal 8's `core/install.php` by a significant amount. This is a VM with 4 physical cpu cores (no hyperthreading).

```
$ ab -c4 -n 100 http://d8.local/core/install.php

This is ApacheBench, Version 2.3 <$Revision: 1663405 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking local.pubcentral.io (be patient).....done


Server Software:        Apache/2.4.16
Server Hostname:        local.pubcentral.io
Server Port:            80

Document Path:          /core/install.php
Document Length:        11044 bytes

Concurrency Level:      4
Time taken for tests:   56.142 seconds
Complete requests:      100
Failed requests:        8
   (Connect: 0, Receive: 0, Length: 8, Exceptions: 0)
Total transferred:      1139791 bytes
HTML transferred:       1104391 bytes
Requests per second:    1.78 [#/sec] (mean)
Time per request:       2245.663 [ms] (mean)
Time per request:       561.416 [ms] (mean, across all concurrent requests)
Transfer rate:          19.83 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:  1996 2239 236.3   2163    3052
Waiting:     1995 2238 236.2   2163    3052
Total:       1996 2239 236.3   2164    3052

Percentage of the requests served within a certain time (ms)
  50%   2164
  66%   2281
  75%   2379
  80%   2429
  90%   2610
  95%   2763
  98%   2929
  99%   3052
 100%   3052 (longest request)
```

After this PR, and vagrant reloading the box:

```
This is ApacheBench, Version 2.3 <$Revision: 1663405 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking local.pubcentral.io (be patient).....done


Server Software:        Apache/2.4.16
Server Hostname:        local.pubcentral.io
Server Port:            80

Document Path:          /core/install.php
Document Length:        11044 bytes

Concurrency Level:      4
Time taken for tests:   24.316 seconds
Complete requests:      100
Failed requests:        7
   (Connect: 0, Receive: 0, Length: 7, Exceptions: 0)
Total transferred:      1139792 bytes
HTML transferred:       1104392 bytes
Requests per second:    4.11 [#/sec] (mean)
Time per request:       972.641 [ms] (mean)
Time per request:       243.160 [ms] (mean, across all concurrent requests)
Transfer rate:          45.78 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   836  956 124.3    911    1774
Waiting:      835  956 124.3    910    1773
Total:        836  956 124.3    911    1774

Percentage of the requests served within a certain time (ms)
  50%    911
  66%    935
  75%    959
  80%    982
  90%   1148
  95%   1187
  98%   1237
  99%   1774
 100%   1774 (longest request)
```
