### PR TITLE
Disable vbguest automatic addition updates

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -101,6 +101,11 @@ Vagrant.configure("2") do |config|
   config.vm.box_version = "1.8.1"
   config.vm.box_check_update = true
 
+  # Disable vbguest autoupdating as we boot from a read-only ISO.
+  if Vagrant.has_plugin?("vagrant-vbguest")
+    config.vbguest.auto_update = false
+  end
+
   ## Network ##
 
   # The default box private network IP is 192.168.10.10


### PR DESCRIPTION
https://github.com/dotless-de/vagrant-vbguest is a super handy plugin for keeping guest additions up to date.

Unfortunately, it throws errors with this base box because we're booting from a read-only docker ISO. The errors don't block booting the machine, but they are concerning if you don't know why file writes are failing.
