### PR TITLE
Fixed Version requirements for Vagrant and Virtual Box.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The stock boot2docker currently mounts host volumes via the default VirtualBox G
 
 <a name="requirements"></a>
 ## Prerequisites
-1. [VirtualBox](https://www.virtualbox.org/) 1.7.3+
-2. [Vagrant](https://www.vagrantup.com/) 5.0+
+1. [VirtualBox](https://www.virtualbox.org/) 5.0+
+2. [Vagrant](https://www.vagrantup.com/) 1.7.3+
 3. [Babun](http://babun.github.io) - A Linux-type shell, **Windows only**
 
 Proceed to [Setup and usage](#setup) if you already have all prerequisites installed or prefer to install some/all manually.  


### PR DESCRIPTION
There is a small glitch in the readme.md, the version numbers for VirtualBox and Vagrant are mixed up. Not a big deal but irritating :)
