### PR TITLE
Set the attribute caching of files and directories to 2 seconds

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -132,7 +132,7 @@ Vagrant.configure("2") do |config|
     @ui.success "Using nfs2 synced folder option"
     config.vm.synced_folder vagrant_root, vagrant_mount_point,
       type: "nfs",
-      mount_options: ["nolock", "noacl", "nocto", "noatime", "nodiratime", "vers=3", "tcp"]
+      mount_options: ["nolock", "noacl", "nocto", "noatime", "nodiratime", "vers=3", "tcp", "actimeo=2"]
     config.nfs.map_uid = Process.uid
     config.nfs.map_gid = Process.gid
   # smb: Better performance on Windows. Requires Vagrant to be run with admin privileges.


### PR DESCRIPTION
We ran into an issue where the watch functionality of gulp was taking sometimes more than 10 seconds to find a change in the assets files. This change greatly reduces the minimum and maximum cache times of files and directories from anywhere between 30 and 60 seconds to a minimum and maximum 2 seconds.

This instantly solved our problem with watching for changes with Gulp.
