### PR TITLE
Cleanup of installation under windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Prerequisites are installed using **babun** and **chocolatey** (chocolatey will 
 
     bash <(curl -s https://raw.githubusercontent.com/blinkreaction/boot2docker-vagrant/master/scripts/presetup-win.sh)
 
+**Windows (alternative)**
+
+If you don't want babun, run this script in administrator mode (right clic execute into administrator), the file must be in your computer for security purpose.
+
+    /scripts/presetup-win.cmd
+
+Then you must continue using manual installation
 
 <a name="setup"></a>
 ## Setup and usage
@@ -53,7 +60,7 @@ Designate a root folder that the VM will have access to (e.g. `~/Projects`) and 
     ```
 
 3. Verify your setup by checking docker client and server versions
-    
+
     ```    
     docker version
     ```

--- a/scripts/presetup-win.cmd
+++ b/scripts/presetup-win.cmd
@@ -1,12 +1,25 @@
-REM Installing Chocolatey
+@echo off
+net session >nul 2>&1
+if %errorLevel% == 0 (
+    echo Administrator OK.
+) else (
+    echo Error : you must be administrator.
+    pause
+    exit
+)
+
+REM *** Installing Chocolatey ***
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
 
-REM Installing virtualbox
-choco install virtualbox -y
+REM *** Installing Packages ***
+choco install virtualbox vagrant git docker docker-compose -y
+choco upgrade virtualbox vagrant git docker docker-compose -y
 
-REM Killing the default adapter and DHCP server to avoid network issues down the road
-"C:\Program Files\Oracle\VirtualBox\VBoxManage" dhcpserver remove --netname "HostInterfaceNetworking-VirtualBox Host-Only Ethernet Adapter"
-"C:\Program Files\Oracle\VirtualBox\VBoxManage" hostonlyif remove "VirtualBox Host-Only Ethernet Adapter"
+REM *** Refresh PATH ***
+SET PATH=%PATH%
 
-REM Installing vagrant
-choco install vagrant -y
+REM *** Adjusting git defaults ***
+git config --global core.autocrlf input
+git config --system core.longpaths true
+
+pause

--- a/scripts/presetup-win.cmd
+++ b/scripts/presetup-win.cmd
@@ -8,12 +8,17 @@ if %errorLevel% == 0 (
     exit
 )
 
+SET version_docker=1.9.1
+SET version_dockercompose=1.5.2
+
 REM *** Installing Chocolatey ***
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
 
 REM *** Installing Packages ***
-choco install virtualbox vagrant git docker docker-compose -y
-choco upgrade virtualbox vagrant git docker docker-compose -y
+choco install virtualbox vagrant git -y
+choco upgrade virtualbox vagrant git -y
+choco install docker -y -version %version_docker%
+choco install docker-compose -y -version %version_dockercompose%
 
 REM *** Refresh PATH ***
 SET PATH=%PATH%

--- a/scripts/presetup-win.sh
+++ b/scripts/presetup-win.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-DOCKER_VERSION=1.9.1
-DOCKER_COMPOSE_VERSION=1.5.2
 
 # Console colors
 red='\033[0;31m'
@@ -26,18 +24,3 @@ curl -sSL https://raw.githubusercontent.com/blinkreaction/boot2docker-vagrant/${
 curl -sSL https://raw.githubusercontent.com/blinkreaction/boot2docker-vagrant/${B2D_BRANCH}/scripts/presetup-win.vbs -o $WINDIR/Temp/presetup-win.vbs
 echo-yellow "Setup needs administrator privileges to contiue..."
 cscript $WINDIR/Temp/presetup-win.vbs
-
-# Install Docker
-echo-green "Installing docker cli v${DOCKER_VERSION}..."
-curl -sSL https://get.docker.com/builds/Windows/i386/docker-$DOCKER_VERSION.exe -o /usr/local/bin/docker
-chmod +x /usr/local/bin/docker
-
-# Install Docker Compose
-echo-green "Installing docker-compose v${DOCKER_COMPOSE_VERSION}..."
-curl -sSL https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-Windows-x86_64.exe > /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-
-# Git settings
-echo-green "Adjusting git defaults..."
-git config --global core.autocrlf input
-git config --system core.longpaths true


### PR DESCRIPTION
Adding alternate install under windows (not using babun)
Using choco to install docker and docker-compose (have cleaned presetup-win.sh)
The new presetup-win.cmd script now check administrator rights and can be used "standalone" for a quick installation 
